### PR TITLE
Use Langchain for HF queries

### DIFF
--- a/llm_config_generator.py
+++ b/llm_config_generator.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Dict
 import os
-import requests
 import yaml
 import pandas as pd
+from langchain.llms import HuggingFaceHub
 from utils import detect_schema, write_yaml
 
 
@@ -21,19 +21,12 @@ HF_API_TOKEN = os.environ.get("HF_API_TOKEN")
 
 
 def _query_huggingface(prompt: str) -> str:
-    """Send a text generation request to the Hugging Face inference API."""
-    headers = {"Authorization": f"Bearer {HF_API_TOKEN}"} if HF_API_TOKEN else {}
-    url = f"https://api-inference.huggingface.co/models/{HF_MODEL}"
-    payload = {"inputs": prompt, "options": {"wait_for_model": True}}
-    resp = requests.post(url, headers=headers, json=payload, timeout=60)
-    resp.raise_for_status()
-    data = resp.json()
-    if isinstance(data, list) and data and "generated_text" in data[0]:
-        return data[0]["generated_text"]
-    if isinstance(data, dict) and "generated_text" in data:
-        return data["generated_text"]
-    # Fall back to string conversion
-    return str(data)
+    """Generate text using a Hugging Face model via LangChain."""
+    llm = HuggingFaceHub(
+        repo_id=HF_MODEL,
+        huggingfacehub_api_token=HF_API_TOKEN,
+    )
+    return llm(prompt)
 
 
 def generate_config(data_path: str, user_prompt: str, output_path: str = "config.yaml") -> Dict[str, Any]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 plotly
 pymongo
 SQLAlchemy
+langchain


### PR DESCRIPTION
## Summary
- replace manual HTTPS calls with `HuggingFaceHub` from LangChain in `llm_config_generator`
- require `langchain` library

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_68683dca4528832c8566a28eb0548a46